### PR TITLE
Recognize more patterns in cue text

### DIFF
--- a/src/ridewithgps_to_cuesheet/conversion.py
+++ b/src/ridewithgps_to_cuesheet/conversion.py
@@ -89,12 +89,8 @@ def generate_excel(filename: str, csv_values: List[List[str]], opts: GenerationO
             last_dist = Decimal("0.0")
 
             if opts.verbose:
-                tmp = f"We're on turn {cue_num} at {turn.dist}kms"
-                if "onto" in turn.description:
-                    tmp = f"({turn.description[turn.description.find('onto') + 5 :]}) {tmp}"
-                else:
-                    tmp = f"{turn.description}: {tmp}"
-                logger.debug(f"{tmp}\n\testimated distance is {curr_dist}kms since last")
+                logger.debug(f"{turn.description}: We're on turn {cue_num} at {turn.dist}km\n"
+                             f"\testimated distance is {curr_dist}km since last")
 
             _write_data_row(
                 worksheet,

--- a/src/ridewithgps_to_cuesheet/conversion.py
+++ b/src/ridewithgps_to_cuesheet/conversion.py
@@ -84,8 +84,7 @@ def generate_excel(filename: str, csv_values: List[List[str]], opts: GenerationO
         page_break_list = []
         last_row_was_control = False
 
-        for cue_num in range(len(cues)):
-            turn = cues[cue_num]
+        for cue_num, turn in enumerate(cues):
             curr_dist = turn.dist - last_dist
             last_dist = Decimal("0.0")
 

--- a/src/ridewithgps_to_cuesheet/conversion.py
+++ b/src/ridewithgps_to_cuesheet/conversion.py
@@ -321,7 +321,7 @@ def _add_footer_information(worksheet: Worksheet, row_num: int, last_col_letter:
     row_num += 2
     worksheet.merge_range(
         f"A{row_num}:{last_col_letter}{row_num}",
-        data="ST=Turn Around, BL=Bear Left, BR=Bear Right, CO=Continue On, L/R=Left Immediate Right",
+        data="TA=Turn Around, BL=Bear Left, BR=Bear Right, CO=Continue On",
         cell_format=formats.black_title,
     )
     worksheet.set_row(row=row_num - 1, height=CONTROL_ROW_HEIGHT * 2)

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -161,6 +161,40 @@ def test_parse_with_custom_end_indicator():
     assert cues[-1].description != "ARRIVÉE: End of route"  # End is NOT the end_indicator
 
 
+def test_parse_route_with_turns():
+    csv_data = [
+        ["Start", "Start of route", "0", "0", ""],
+        ["Right", "Turn right onto Test St", "0.5", "10.0", ""],
+        ["Left", "Turn left onto Main St", "2.0", "15.0", ""],
+        ["Food", "Food stop at cafe", "5.0", "20.0", ""],
+        ["Control", "Control checkpoint", "10.0", "25.0", ""],
+        ["Right", "At roundabout, take exit 2 onto Sesame Street", "11.0", "25.5", ""],
+        ["Slight Left", "Turn slight left onto Big Bird Lane", "12.0", "30.5", ""],
+        ["Right", "Keep right onto Big Bird Lane", "12.5", "32.2", ""],
+        ["Uturn", "Make a U-turn on Big Bird Lane", "13.5", "35.0", ""],
+        ["Left", "Turn left into Bletchley Park", "14.0", "45.0", ""],
+        ["Control", "Control 2: Bletchley Park visitor centre", "14.2", "45.2", ""],
+        ["End", "End of route", "20.0", "30.0", ""],
+    ]
+    expected_cues = [
+        Cue('', 'DÉPART', Decimal('0.5'), is_control=True, last_dist=Decimal('0')),
+        Cue('R', 'Test St', Decimal('2.0'), last_dist=Decimal('0.5')),
+        Cue('L', 'Main St', Decimal('5.0'), last_dist=Decimal('2.0')),
+        Cue('', 'Food stop at cafe', Decimal('10.0'), last_dist=Decimal('5.0')),
+        Cue('', 'Control checkpoint', Decimal('11.0'), is_control=True, last_dist=Decimal('10.0')),
+        Cue('R', 'Sesame Street (roundabout exit 2)', Decimal('12.0'), last_dist=Decimal('11.0')),
+        Cue('BL', 'Big Bird Lane', Decimal('12.5'), last_dist=Decimal('12.0')),
+        Cue('R', 'Big Bird Lane', Decimal('13.5'), last_dist=Decimal('12.5')),
+        Cue('TA', 'Big Bird Lane', Decimal('14.0'), last_dist=Decimal('13.5')),
+        Cue('L', 'Bletchley Park', Decimal('14.2'), last_dist=Decimal('14.0')),
+        Cue('', 'Bletchley Park visitor centre', Decimal('20.0'), is_control=True, last_dist=Decimal('14.2')),
+        Cue('', 'ARRIVÉE', Decimal('-1.0'), is_control=True, last_dist=Decimal('20.0')),
+    ]
+    opts = GenerationOptions()
+    cues = _parse_to_cues(csv_data, opts)
+    assert cues == expected_cues
+
+
 def test_parse_empty_data():
     csv_data = []
     opts = GenerationOptions()


### PR DESCRIPTION
Main feature is to recognize cue text such as...
    
> Control *1*: Wonderland
> Continue *straight* onto Sesame Street
> *At roundabout, take exit 2 onto* Sesame Street
> Turn *slight* left onto Sesame Street
> *Keep* right onto Sesame Street
> *Make a U-turn* on Sesame Street
> Turn left *into* Bletchley Park
    
Code uses walrus operator (PEP 572, Python ≥ 3.8), but `pyproject.toml` already requires Python ≥ 3.9.

Also a couple of minor changes while I'm looking at `conversion.py`.

Tested against https://ridewithgps.com/routes/51695232